### PR TITLE
Added ability to deploy on clusters with ceph-osd nodes

### DIFF
--- a/deployment_scripts/link_astute_file.sh
+++ b/deployment_scripts/link_astute_file.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 source ./common
-ROLES="primary-controller controller compute cinder"
+ROLES="primary-controller controller compute cinder ceph-osd"
 ASTUTE_FILE=/etc/astute.yaml
 
 function check_symlink () {


### PR DESCRIPTION
In order to be able to use mellanox HBAs on nodes that only have a role of 'ceph-osd', the plugin must attempt to link astute.yaml to ceph-osd.yaml.  Without this, deployment fails due to missing astute.yaml.